### PR TITLE
Fix: #3876 Update task utils: removeIterationFromTaskRefName

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/utils/TaskUtils.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/TaskUtils.java
@@ -26,6 +26,10 @@ public class TaskUtils {
 
     public static String removeIterationFromTaskRefName(String referenceTaskName) {
         String[] tokens = referenceTaskName.split(TaskUtils.LOOP_TASK_DELIMITER);
-        return tokens.length > 0 ? tokens[0] : referenceTaskName;
+        int length = tokens.length;
+        return length > 1 ? String.join(
+                TaskUtils.LOOP_TASK_DELIMITER,
+                Arrays.copyOf(tokens, length - 1)
+        ) : referenceTaskName;
     }
 }


### PR DESCRIPTION
Parsing name is not considering existing task ref name with double underscores

- This is not fully fixing the use of this function. There needs to be some kind of validation against the user from setting up the taskRefName with double underscore

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #3876
If this is not there, then task creation would go into infinite loop. This can be used to cause issues in conductor installation

Alternatives considered
----
Add validation in the create start workflow / create workflow definition api

_Describe alternative implementation you have considered_
